### PR TITLE
Implementata gestione dei ruoli (utenti, operatori, admin)

### DIFF
--- a/middleware/authorizeRole.js
+++ b/middleware/authorizeRole.js
@@ -1,0 +1,19 @@
+function authorizeRole(allowedRoles) {
+    return (req, res, next) => {
+        if (!allowedRoles.includes(req.user.ruolo)) {
+            return res.status(403).json({ message: 'Accesso vietato: ruolo non autorizzato.' });
+        }
+        next();
+    };
+}
+
+module.exports = authorizeRole;
+
+//funzione controlla se ruolo dell'utente appartiene a lista di ruoli permessi "allowedRoles"
+//da utilizzare negli endpoint per limitare l'accesso a determinate categorie di utenti
+
+/* ESEMPIO:
+const authorizeRole = require('../middleware/authorizeRole');
+// Solo gli operatori del Comune possono aggiornare lo stato di una segnalazione
+router.put('/segnalazioni/:id/stato', authenticateToken, authorizeRole(['operator']), async (req, res) => {...
+*/

--- a/models/User.js
+++ b/models/User.js
@@ -32,11 +32,11 @@ const UserSchema = new mongoose.Schema({
         type: mongoose.Schema.Types.ObjectId,
         ref: 'ImpostazioniUtente'
     },
-    // tipoUtente: { // Potrebbe servire per GestioneAutenticazione
-    //     type: String,
-    //     enum: ['utente', 'Comune', 'admin'],
-    //     default: 'utente'
-    // }
+    ruolo: { // Serve per controllo dei ruoli
+        type: String,
+        enum: ['utente', 'operatore', 'admin'],
+        default: 'utente'
+    }
 
 }, { timestamps: true }); // timestamps aggiunge createdAt e updatedAt
 

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -68,7 +68,8 @@ router.post('/register', async (req, res) => {
             email,
             passwordHash: password, // La passwordHash verrà hashata nel pre-save hook
             nome,
-            cognome
+            cognome,
+            ruolo: 'utente' //forza il ruolo di ogni nuovo registrato a utente. Solo admin può promuovere a 'operatore' tramite endpoint dedicato
         });
 
         const savedUser = await newUser.save();
@@ -84,7 +85,7 @@ router.post('/register', async (req, res) => {
         await savedUser.save();
 
         // Genera token JWT
-        const payload = { userId: savedUser._id };
+        const payload = { userId: savedUser._id, ruolo: user.ruolo};   //modificato: genera token anche a partire dal ruolo dell'utente
         const token = jwt.sign(payload, process.env.JWT_SECRET, { expiresIn: '1h' });
 
         // Rimuovi passwordHash dalla risposta
@@ -152,7 +153,7 @@ router.post('/login', async (req, res) => {
         }
 
         // Genera token JWT
-        const payload = { userId: user._id };
+        const payload = { userId: user._id, ruolo: user.ruolo};   //modificato: genera token anche a partire dal ruolo dell'utente
         const token = jwt.sign(payload, process.env.JWT_SECRET, { expiresIn: '1h' });
 
         const userToReturn = user.toObject();


### PR DESCRIPTION
- Aggiunto campo 'ruolo' nel modello User per supportare i ruoli 'utente', 'operatore' e 'admin'.
- Creati endpoint per promuovere utenti a 'operatore' e registrare nuovi operatori (accessibili solo da admin).
- Implementato middleware 'authorizeRole' per proteggere gli endpoint in base al ruolo.
- Modificata la generazione del token JWT per includere il ruolo dell'utente.
- Aggiornato Swagger per riflettere le nuove operazioni e i ruoli.